### PR TITLE
DE-136 - test CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,16 +54,17 @@ pipeline {
                     steps {
                         withDockerRegistry(credentialsId: "${DOCKER_CREDENTIALS_ID}", url: "") {
                             sh 'sh build-n-publish.sh --image=${DOCKER_IMAGE_NAME} --commit=${GIT_COMMIT} --name=main'
+                            sh 'sh build-n-publish.sh --image=${DOCKER_IMAGE_NAME} --commit=${GIT_COMMIT} --name=TEST'
                         }
                     }
                 }
-                stage('Publish pre-release images from INT') {
+                stage('Publish pre-release images from TEST') {
                     when {
-                        branch 'INT'
+                        branch 'TEST'
                     }
                     steps {
                         withDockerRegistry(credentialsId: "${DOCKER_CREDENTIALS_ID}", url: "") {
-                            sh 'sh build-n-publish.sh --image=${DOCKER_IMAGE_NAME} --commit=${GIT_COMMIT} --name=INT'
+                            sh 'sh build-n-publish.sh --image=${DOCKER_IMAGE_NAME} --commit=${GIT_COMMIT} --name=TEST'
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Publish pre-release images from master') {
+                stage('Publish pre-release images from main') {
                     when {
                         branch 'main'
                     }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ For the moment, for simplicity, we will base it on Swarmpit API, but in the futu
 
 ## Conventions / development processes / CI / CD
 
+When a commit is merged into the `main` branch or when a commit is pushed to the `TEST` branch, an image with the label `TEST` is generated. This image is used in our testing environment (related to Doppler's INT and QA environments).
+
+When we create a branch with the format `v#.#.#` CI creates the following images:
+
+- `v#`
+- `v#.#`
+- `v#.#.#`
+- `v#.#.#_{commitId}`
+
+In the Production environment, we use the image `v1`.
+
 See more information about these topics in
 
 - [Hello-Microservice repository](https://github.com/FromDoppler/hello-microservice/blob/main/README.md)


### PR DESCRIPTION
Hi team, 

I realized that, in this case, we have only two environments (because we have only two swarms: production and test).

So, in place of using the `main` (or `master`) image for _QA_ environment and `INT` for _INT_ environment, I will use `TEST` for the _test_ environment.

In the readme:

> When a commit is merged into the `main` branch or when a commit is pushed to the `TEST` branch, an image with the label `TEST` is generated. This image is used in our testing environment (related to Doppler's INT and QA environments).

Related to https://github.com/MakingSense/doppler-swarm/pull/391