### PR TITLE
DE-136 - Service selection logic

### DIFF
--- a/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
+++ b/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
@@ -140,5 +140,106 @@ namespace Doppler.CDHelper
             swarmClientMock.Verify(x => x.RedeployService(selectedServiceId1), Times.Once);
             swarmClientMock.Verify(x => x.RedeployService(selectedServiceId2), Times.Once);
         }
+
+        [Fact]
+        public async Task POST_dockerhub_handler_should_filter_services_and_update_filtered_ones()
+        {
+            // Arrange
+            const string helloRepositoryName = "dopplerdock/hello-microservice";
+            const string cdHelperRepositoryName = "dopplerdock/doppler-cd-helper";
+            const string intTag = "INT";
+            const string qaTag = "QA";
+
+            var hookData = new DockerHubHookData()
+            {
+                callback_url = "https://callback_url",
+                push_data = new DockerHubHookDataPushData()
+                {
+                    tag = intTag
+                },
+                repository = new DockerHubHookDataRepository()
+                {
+                    repo_name = helloRepositoryName
+                }
+            };
+
+            // should be redeployed
+            var helloServiceInt = new SwarmServiceDescription()
+            {
+                id = "penpnhep0bsciofxzd542v62n",
+                serviceName = "hello-int_hello-service",
+                repository = new SwarmServiceDescriptionRepository()
+                {
+                    name = helloRepositoryName,
+                    tag = intTag,
+                    imageDigest = "sha256:c7a459f13dbf082fe9b6631783f897d54978a32cc91aa8dee5fcb5630fa18a0b"
+                }
+            };
+
+            // should not be redeployed
+            var cdHelperServiceInt = new SwarmServiceDescription()
+            {
+                id = "qn3jq891p77lyigwysj4fcww2",
+                serviceName = "swarmpit_doppler-cd-helper",
+                repository = new SwarmServiceDescriptionRepository()
+                {
+                    name = cdHelperRepositoryName,
+                    tag = intTag,
+                    imageDigest = "sha256:a247c00ad3ae505bbcbcbc48eb58a50a16e0628339803da65c9081be365b3b9c"
+                }
+            };
+
+            // Exactly the same image with another configuration
+            // should be redeployed
+            var helloServiceIntWithAlternativeConfiguration = helloServiceInt with
+            {
+                id = "riq6gv8d0xr9rpagr9lg5xqrw",
+                serviceName = "hello-int_hello-service_with_alternative_configuration",
+            };
+
+            // The same image name with a different tag with another configuration
+            // should not be redeployed
+            var helloServiceQA = helloServiceInt with
+            {
+                id = "riq6gv8d0xr9rpagr9lg5xqrw",
+                serviceName = "hello-int_hello-service_with_alternative_configuration",
+                repository = helloServiceInt.repository with
+                {
+                    tag = qaTag
+                }
+            };
+
+            var currentServices = new[] {
+                helloServiceInt,
+                cdHelperServiceInt,
+                helloServiceIntWithAlternativeConfiguration,
+                helloServiceQA
+            };
+
+            var swarmClientMock = new Mock<ISwarmClient>();
+
+            swarmClientMock.Setup(x => x.GetServices()).ReturnsAsync(currentServices);
+
+            using var customFactory = _factory.WithWebHostBuilder(c =>
+            {
+                c.ConfigureServices(s => s
+                    .AddSingleton(swarmClientMock.Object));
+            });
+
+            var client = customFactory.CreateClient(new WebApplicationFactoryClientOptions()
+            {
+                AllowAutoRedirect = false
+            });
+
+            // Act
+            var response = await client.PostAsync(
+                "/hooks/my_secret/",
+                JsonContent.Create(hookData));
+
+            // Assert
+            swarmClientMock.Verify(x => x.RedeployService(It.IsAny<string>()), Times.Exactly(2));
+            swarmClientMock.Verify(x => x.RedeployService(helloServiceInt.id), Times.Once);
+            swarmClientMock.Verify(x => x.RedeployService(helloServiceIntWithAlternativeConfiguration.id), Times.Once);
+        }
     }
 }

--- a/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
+++ b/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
@@ -31,6 +31,8 @@ namespace Doppler.CDHelper
             // Arrange
             var secret = "my_secret";
             var callback_url = "https://registry.hub.docker.com/u/dopplerdock/doppler-cd-helper/hook/2jiedged52hbhfi1acgdggdi1ih123456/";
+            var tag = "tag";
+            var repo_name = "repoName";
 
             var loggerMock = new Mock<ILogger<HooksController>>();
 
@@ -50,6 +52,8 @@ namespace Doppler.CDHelper
                 JsonContent.Create(new
                 {
                     callback_url,
+                    push_data = new { tag },
+                    repository = new { repo_name }
                 }));
 
             // Assert
@@ -71,7 +75,9 @@ namespace Doppler.CDHelper
             Assert.Contains(logParameters, x =>
                 x.Key == "@data"
                 && x.Value is DockerHubHookData data
-                && data.callback_url == callback_url);
+                && data.callback_url == callback_url
+                && data.push_data.tag == tag
+                && data.repository.repo_name == repo_name);
         }
 
         [Fact]
@@ -79,6 +85,8 @@ namespace Doppler.CDHelper
         {
             // Arrange
             var callback_url = "https://registry.hub.docker.com/u/dopplerdock/doppler-cd-helper/hook/2jiedged52hbhfi1acgdggdi1ih123456/";
+            var tag = "tag";
+            var repo_name = "repoName";
 
             var currentServices = new[] { new SwarmServiceDescription() };
 
@@ -98,7 +106,9 @@ namespace Doppler.CDHelper
             swarmServiceSelectorMock
                 .Setup(x => x.GetServicesToRedeploy(
                     It.Is<DockerHubHookData>(v =>
-                        v.callback_url == callback_url),
+                        v.callback_url == callback_url
+                        && v.push_data.tag == tag
+                        && v.repository.repo_name == repo_name),
                     currentServices))
                 .Returns(selectedServices);
 
@@ -120,6 +130,8 @@ namespace Doppler.CDHelper
                 JsonContent.Create(new
                 {
                     callback_url,
+                    push_data = new { tag },
+                    repository = new { repo_name }
                 }));
 
             // Assert

--- a/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
+++ b/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
@@ -30,7 +30,7 @@ namespace Doppler.CDHelper
         {
             // Arrange
             var secret = "my_secret";
-            var callbackUrl = "https://registry.hub.docker.com/u/dopplerdock/doppler-cd-helper/hook/2jiedged52hbhfi1acgdggdi1ih123456/";
+            var callback_url = "https://registry.hub.docker.com/u/dopplerdock/doppler-cd-helper/hook/2jiedged52hbhfi1acgdggdi1ih123456/";
 
             var loggerMock = new Mock<ILogger<HooksController>>();
 
@@ -47,7 +47,10 @@ namespace Doppler.CDHelper
             // Act
             var response = await client.PostAsync(
                 $"/hooks/{secret}/",
-                JsonContent.Create(new { callback_url = callbackUrl }));
+                JsonContent.Create(new
+                {
+                    callback_url,
+                }));
 
             // Assert
 
@@ -65,16 +68,17 @@ namespace Doppler.CDHelper
                 Times.Once);
 
             Assert.Contains($"secret: {secret};", logParameters.ToString());
-            Assert.Contains(
-                logParameters,
-                x => x.Key == "@data" && x.Value is DockerHubHookData data && data.callback_url == callbackUrl);
+            Assert.Contains(logParameters, x =>
+                x.Key == "@data"
+                && x.Value is DockerHubHookData data
+                && data.callback_url == callback_url);
         }
 
         [Fact]
         public async Task POST_dockerhub_handler_should_get_services_from_SwarmClient_filter_with_service_selector_and_redeploy_selected_ones()
         {
             // Arrange
-            var callbackUrl = "https://registry.hub.docker.com/u/dopplerdock/doppler-cd-helper/hook/2jiedged52hbhfi1acgdggdi1ih123456/";
+            var callback_url = "https://registry.hub.docker.com/u/dopplerdock/doppler-cd-helper/hook/2jiedged52hbhfi1acgdggdi1ih123456/";
 
             var currentServices = new[] { new SwarmServiceDescription() };
 
@@ -93,7 +97,8 @@ namespace Doppler.CDHelper
 
             swarmServiceSelectorMock
                 .Setup(x => x.GetServicesToRedeploy(
-                    It.Is<DockerHubHookData>(v => v.callback_url == callbackUrl),
+                    It.Is<DockerHubHookData>(v =>
+                        v.callback_url == callback_url),
                     currentServices))
                 .Returns(selectedServices);
 
@@ -112,7 +117,10 @@ namespace Doppler.CDHelper
             // Act
             var response = await client.PostAsync(
                 "/hooks/my_secret/",
-                JsonContent.Create(new { callback_url = callbackUrl }));
+                JsonContent.Create(new
+                {
+                    callback_url,
+                }));
 
             // Assert
             swarmClientMock.Verify(x => x.GetServices(), Times.Once);

--- a/Doppler.CDHelper/Controllers/HooksController.cs
+++ b/Doppler.CDHelper/Controllers/HooksController.cs
@@ -36,6 +36,9 @@ namespace Doppler.CDHelper.Controllers
 
             foreach (var service in servicesToRedeploy)
             {
+                // TODO: Consider compare local service digest with docker hub one.
+                // Since hook data does not contain digest information, we cannot confirm if
+                // the service is not already updated.
                 _logger.LogInformation("Redeploying {@service}", service);
                 await _swarmClient.RedeployService(service.id);
             }

--- a/Doppler.CDHelper/DockerHubHookData.cs
+++ b/Doppler.CDHelper/DockerHubHookData.cs
@@ -7,7 +7,9 @@ namespace Doppler.CDHelper
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Allow properties with camelCase because it represents a JSON")]
     public record DockerHubHookData
     {
+        public DockerHubHookDataPushData push_data { get; init; }
         public string callback_url { get; init; }
+        public DockerHubHookDataRepository repository { get; init; }
 
         // TODO: add more properties in order to represent the Docker Hub data:
         // {
@@ -35,5 +37,20 @@ namespace Doppler.CDHelper
         //         "repo_name": "dopplerdock/doppler-cd-helper"
         //     }
         // }
+    }
+
+    [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Allow properties with underscore because it represents a JSON")]
+    [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Allow properties with camelCase because it represents a JSON")]
+    public record DockerHubHookDataPushData
+    {
+        public string tag { get; init; }
+    }
+
+
+    [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Allow properties with underscore because it represents a JSON")]
+    [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Allow properties with camelCase because it represents a JSON")]
+    public record DockerHubHookDataRepository
+    {
+        public string repo_name { get; init; }
     }
 }

--- a/Doppler.CDHelper/DockerHubHookData.cs
+++ b/Doppler.CDHelper/DockerHubHookData.cs
@@ -11,6 +11,7 @@ namespace Doppler.CDHelper
         public string callback_url { get; init; }
         public DockerHubHookDataRepository repository { get; init; }
 
+        // IMPORTANT: The digest seems not be present in this payload!
         // TODO: add more properties in order to represent the Docker Hub data:
         // {
         //     "push_data": {

--- a/Doppler.CDHelper/Startup.cs
+++ b/Doppler.CDHelper/Startup.cs
@@ -26,7 +26,7 @@ namespace Doppler.CDHelper
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDummySwarmClient();
-            services.AddDummySwarmServiceSelector();
+            services.AddSwarmServiceSelector();
             services.AddControllers();
             services.AddSwaggerGen(c =>
             {

--- a/Doppler.CDHelper/SwarmClient/SwarmClientServiceCollectionExtensions.cs
+++ b/Doppler.CDHelper/SwarmClient/SwarmClientServiceCollectionExtensions.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 new SwarmServiceDescription()
                 {
-                    id = "dummyId"
+                    id = "penpnhep0bsciofxzd542v62n",
+                    serviceName = "hello-int_hello-service",
+                    repository = new SwarmServiceDescriptionRepository()
+                    {
+                        imageDigest = "sha256:c7a459f13dbf082fe9b6631783f897d54978a32cc91aa8dee5fcb5630fa18a0b",
+                        name = "dopplerdock/hello-microservice",
+                        tag = "INT"
+                    }
                 }
             };
             services.AddSingleton<DummySwarmClientResult>(new DummySwarmClientResult(clientResult));

--- a/Doppler.CDHelper/SwarmClient/SwarmServiceDescription.cs
+++ b/Doppler.CDHelper/SwarmClient/SwarmServiceDescription.cs
@@ -9,7 +9,9 @@ namespace Doppler.CDHelper.SwarmClient
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Allow properties with camelCase because it represents a JSON")]
     public record SwarmServiceDescription
     {
+        public SwarmServiceDescriptionRepository repository { get; init; }
         public string id { get; init; }
+        public string serviceName { get; init; }
 
         // TODO: add more properties in order to represent the Swarmpit response:
         //   {
@@ -202,5 +204,13 @@ namespace Doppler.CDHelper.SwarmClient
         //     ],
         //     "stack": "string"
         //   }
+    }
+
+    [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Allow properties with camelCase because it represents a JSON")]
+    public record SwarmServiceDescriptionRepository
+    {
+        public string name { get; init; }
+        public string tag { get; init; }
+        public string imageDigest { get; init; }
     }
 }

--- a/Doppler.CDHelper/SwarmServiceSelection/SwarmServiceSelectionServiceCollectionExtensions.cs
+++ b/Doppler.CDHelper/SwarmServiceSelection/SwarmServiceSelectionServiceCollectionExtensions.cs
@@ -13,5 +13,11 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ISwarmServiceSelector, DummySwarmServiceSelector>();
             return services;
         }
+
+        public static IServiceCollection AddSwarmServiceSelector(this IServiceCollection services)
+        {
+            services.AddSingleton<ISwarmServiceSelector, SwarmServiceSelector>();
+            return services;
+        }
     }
 }

--- a/Doppler.CDHelper/SwarmServiceSelection/SwarmServiceSelector.cs
+++ b/Doppler.CDHelper/SwarmServiceSelection/SwarmServiceSelector.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Doppler.CDHelper.SwarmClient;
+using Microsoft.Extensions.Logging;
+
+namespace Doppler.CDHelper.SwarmServiceSelection
+{
+    public class SwarmServiceSelector : ISwarmServiceSelector
+    {
+        private readonly ILogger<SwarmServiceSelector> _logger;
+
+        public SwarmServiceSelector(ILogger<SwarmServiceSelector> logger)
+        {
+            _logger = logger;
+        }
+
+        public IEnumerable<SwarmServiceDescription> GetServicesToRedeploy(
+            DockerHubHookData hookData,
+            IEnumerable<SwarmServiceDescription> allSwarmServices)
+            => allSwarmServices.Where(x =>
+                x.repository.name == hookData.repository.repo_name
+                && x.repository.tag == hookData.push_data.tag);
+    }
+}


### PR DESCRIPTION
Hi team!

In this PR I am trying to filter the candidate services to be redeployed based on current services in Swarm and Docker Hub hook payload.

I realized that Docker Hub is not including information about the digest, so, if for any reason we have already run an updated image, it will redeploy again anyway. I added a related comment.

