### PR TITLE
DE-136 - Docker hub hook secret

### DIFF
--- a/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
+++ b/Doppler.CDHelper.Test/DockerHubHandlerTest.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
-using Doppler.CDHelper.Controllers;
+using Doppler.CDHelper.DockerHubIntegration;
 using Doppler.CDHelper.SwarmClient;
 using Doppler.CDHelper.SwarmServiceSelection;
 using Flurl.Http.Testing;

--- a/Doppler.CDHelper/DockerHubIntegration/DockerHubHookData.cs
+++ b/Doppler.CDHelper/DockerHubIntegration/DockerHubHookData.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Doppler.CDHelper
+namespace Doppler.CDHelper.DockerHubIntegration
 {
     [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Allow properties with underscore because it represents a JSON")]
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Allow properties with camelCase because it represents a JSON")]

--- a/Doppler.CDHelper/DockerHubIntegration/DockerHubHookSettings.cs
+++ b/Doppler.CDHelper/DockerHubIntegration/DockerHubHookSettings.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Doppler.CDHelper.DockerHubIntegration
+{
+    public record DockerHubHookSettings
+    {
+        public string Secret { get; init; }
+    }
+}

--- a/Doppler.CDHelper/DockerHubIntegration/DockerHubIntegrationServiceCollectionExtensions.cs
+++ b/Doppler.CDHelper/DockerHubIntegration/DockerHubIntegrationServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Doppler.CDHelper.DockerHubIntegration;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DockerHubIntegrationServiceCollectionExtensions
+    {
+        public static IServiceCollection AddDockerHubIntegration(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            services.Configure<DockerHubHookSettings>(configuration.GetSection("DockerHubHook"));
+            services.AddSingleton<IDockerHubSecretValidator, DockerHubSecretValidator>();
+            return services;
+        }
+    }
+}

--- a/Doppler.CDHelper/DockerHubIntegration/DockerHubSecretValidator.cs
+++ b/Doppler.CDHelper/DockerHubIntegration/DockerHubSecretValidator.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Doppler.CDHelper.DockerHubIntegration
+{
+    public class DockerHubSecretValidator : IDockerHubSecretValidator
+    {
+        private readonly DockerHubHookSettings _settings;
+
+        public DockerHubSecretValidator(IOptions<DockerHubHookSettings> options)
+            => _settings = options.Value;
+
+        public bool IsTheRightSecret(string secret)
+            => _settings.Secret == secret;
+    }
+}

--- a/Doppler.CDHelper/DockerHubIntegration/HooksController.cs
+++ b/Doppler.CDHelper/DockerHubIntegration/HooksController.cs
@@ -7,7 +7,7 @@ using Doppler.CDHelper.SwarmServiceSelection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
-namespace Doppler.CDHelper.Controllers
+namespace Doppler.CDHelper.DockerHubIntegration
 {
     [ApiController]
     public class HooksController

--- a/Doppler.CDHelper/DockerHubIntegration/HooksController.cs
+++ b/Doppler.CDHelper/DockerHubIntegration/HooksController.cs
@@ -13,35 +13,49 @@ namespace Doppler.CDHelper.DockerHubIntegration
     public class HooksController
     {
         private readonly ILogger<HooksController> _logger;
+        private readonly IDockerHubSecretValidator _dockerHubSecretValidator;
         private readonly ISwarmClient _swarmClient;
         private readonly ISwarmServiceSelector _swarmServiceSelector;
 
         public HooksController(
             ILogger<HooksController> logger,
+            IDockerHubSecretValidator dockerHubSecretValidator,
             ISwarmClient swarmClient,
             ISwarmServiceSelector swarmServiceSelector)
         {
             _logger = logger;
+            _dockerHubSecretValidator = dockerHubSecretValidator;
             _swarmClient = swarmClient;
             _swarmServiceSelector = swarmServiceSelector;
         }
 
         [HttpPost("/hooks/{secret}")]
-        public async Task Post([FromRoute] string secret, [FromBody] DockerHubHookData data)
+        public async Task<IActionResult> Post([FromRoute] string secret, [FromBody] DockerHubHookData data)
         {
-            _logger.LogInformation("Hook event! secret: {secret}; data: {@data}", secret, data);
+            if (!_dockerHubSecretValidator.IsTheRightSecret(secret))
+            {
+                _logger.LogWarning("Hook event with a wrong secret! secret: {secret}; data: {@data}", secret, data);
+                return new UnauthorizedResult();
+            }
+
+            _logger.LogDebug("Hook event. Data: {@data}", data);
 
             var currentServices = await _swarmClient.GetServices();
             var servicesToRedeploy = _swarmServiceSelector.GetServicesToRedeploy(data, currentServices);
+
+            _logger.LogDebug("Services to redeploy: {@servicesToRedeploy}", servicesToRedeploy);
 
             foreach (var service in servicesToRedeploy)
             {
                 // TODO: Consider compare local service digest with docker hub one.
                 // Since hook data does not contain digest information, we cannot confirm if
                 // the service is not already updated.
-                _logger.LogInformation("Redeploying {@service}", service);
+                _logger.LogDebug("Redeploying {@service}", service);
                 await _swarmClient.RedeployService(service.id);
+                _logger.LogDebug("Done {@service}", service);
             }
+
+            return new OkResult();
         }
     }
 }

--- a/Doppler.CDHelper/DockerHubIntegration/IDockerHubSecretValidator.cs
+++ b/Doppler.CDHelper/DockerHubIntegration/IDockerHubSecretValidator.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Doppler.CDHelper.DockerHubIntegration
+{
+    public interface IDockerHubSecretValidator
+    {
+        bool IsTheRightSecret(string secret);
+    }
+}

--- a/Doppler.CDHelper/Startup.cs
+++ b/Doppler.CDHelper/Startup.cs
@@ -25,6 +25,7 @@ namespace Doppler.CDHelper
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddDockerHubIntegration(Configuration);
             services.AddSwarmpitSwarmClient(Configuration);
             services.AddSwarmServiceSelector();
             services.AddControllers();

--- a/Doppler.CDHelper/SwarmServiceSelection/DummySwarmServiceSelector.cs
+++ b/Doppler.CDHelper/SwarmServiceSelection/DummySwarmServiceSelector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Doppler.CDHelper.DockerHubIntegration;
 using Doppler.CDHelper.SwarmClient;
 using Microsoft.Extensions.Logging;
 

--- a/Doppler.CDHelper/SwarmServiceSelection/ISwarmServiceSelector.cs
+++ b/Doppler.CDHelper/SwarmServiceSelection/ISwarmServiceSelector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Doppler.CDHelper.DockerHubIntegration;
 using Doppler.CDHelper.SwarmClient;
 
 namespace Doppler.CDHelper.SwarmServiceSelection

--- a/Doppler.CDHelper/SwarmServiceSelection/SwarmServiceSelector.cs
+++ b/Doppler.CDHelper/SwarmServiceSelection/SwarmServiceSelector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Doppler.CDHelper.DockerHubIntegration;
 using Doppler.CDHelper.SwarmClient;
 using Microsoft.Extensions.Logging;
 

--- a/Doppler.CDHelper/appsettings.json
+++ b/Doppler.CDHelper/appsettings.json
@@ -15,5 +15,8 @@
     "AccessToken": "REPLACE_WITH_THE_RIGHT_TOKEN",
     "BaseUrl": "http://app:8080/api/"
   },
+  "DockerHubHook": {
+    "Secret": "REPLACE_WITH_A_SECRET"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Hi team, it is to avoid requests from untrusted sources validated a URL segment against a secret:

![image](https://user-images.githubusercontent.com/1157864/115913693-4dcf5a00-a447-11eb-906b-bad4bfad59f8.png)

https://github.com/MakingSense/doppler-swarm/pull/395