### PR TITLE
DE-227 - Consistent responses for unexpected errors

### DIFF
--- a/Doppler.CDHelper.Test/IntegrationTest1.cs
+++ b/Doppler.CDHelper.Test/IntegrationTest1.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Net;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
+using Doppler.CDHelper.DockerHubIntegration;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Doppler.CDHelper
@@ -22,8 +26,8 @@ namespace Doppler.CDHelper
         [InlineData("/robots.txt", HttpStatusCode.OK, "text/plain")]
         [InlineData("/favicon.ico", HttpStatusCode.OK, "image/x-icon")]
         [InlineData("/swagger/v1/swagger.json", HttpStatusCode.OK, "application/json; charset=utf-8")]
-        [InlineData("/", HttpStatusCode.NotFound, null)]
-        [InlineData("/Not/Found", HttpStatusCode.NotFound, null)]
+        [InlineData("/", HttpStatusCode.NotFound, "application/problem+json; charset=utf-8")]
+        [InlineData("/Not/Found", HttpStatusCode.NotFound, "application/problem+json; charset=utf-8")]
         public async Task GET_endpoints_return_correct_status_and_contentType(string url, HttpStatusCode expectedStatusCode, string expectedContentType)
         {
             // Arrange
@@ -38,6 +42,43 @@ namespace Doppler.CDHelper
             // Assert
             Assert.Equal(expectedStatusCode, response.StatusCode);
             Assert.Equal(expectedContentType, response.Content?.Headers?.ContentType?.ToString());
+        }
+
+        [Fact]
+        public async Task PUT_hooks_should_return_problem_details_when_there_is_an_unexpected_exception()
+        {
+            // Arrange
+            var exceptionMessage = "Test unexpected exception";
+            var dockerHubSecretValidatorMock = new Mock<IDockerHubSecretValidator>();
+            dockerHubSecretValidatorMock.Setup(x => x.IsTheRightSecret(It.IsAny<string>()))
+                .Throws(new Exception(exceptionMessage));
+
+            var client = _factory
+                .WithWebHostBuilder(c =>
+                {
+                    c.ConfigureServices(s =>
+                    {
+                        s.AddSingleton(dockerHubSecretValidatorMock.Object);
+                    });
+                })
+                .CreateClient(new WebApplicationFactoryClientOptions()
+                {
+                    AllowAutoRedirect = false
+                });
+
+            // Act
+            var response = await client.PostAsync("/hooks/my-secret", JsonContent.Create(new object()));
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.Equal("application/problem+json; charset=utf-8", response.Content?.Headers?.ContentType?.ToString());
+            Assert.Contains($"\"detail\":\"{exceptionMessage}\"", responseContent);
+            Assert.Contains("\"title\":\"Internal Server Error\"", responseContent);
+            Assert.Contains("\"type\":\"https://httpstatuses.com/500\"", responseContent);
+            Assert.Contains("\"status\":500", responseContent);
+            Assert.Contains("\"type\":\"System.Exception\"", responseContent);
+            Assert.Contains($"\"raw\":\"System.Exception: {exceptionMessage}", responseContent);
         }
     }
 }

--- a/Doppler.CDHelper/Doppler.CDHelper.csproj
+++ b/Doppler.CDHelper/Doppler.CDHelper.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="3.2.0" />
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="5.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="Serilog.Exceptions" Version="6.1.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />

--- a/Doppler.CDHelper/Startup.cs
+++ b/Doppler.CDHelper/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Hellang.Middleware.ProblemDetails;
 
 namespace Doppler.CDHelper
 {
@@ -29,6 +30,7 @@ namespace Doppler.CDHelper
             {
                 c.LoggingFields = Microsoft.AspNetCore.HttpLogging.HttpLoggingFields.All;
             });
+            services.AddProblemDetails();
             services.AddDockerHubIntegration(Configuration);
             services.AddSwarmpitSwarmClient(Configuration);
             services.AddSwarmServiceSelector();
@@ -50,10 +52,7 @@ namespace Doppler.CDHelper
         {
             app.UseHttpLogging();
 
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
+            app.UseProblemDetails();
 
             app.UseSwagger();
             app.UseSwaggerUI(c => c.SwaggerEndpoint("v1/swagger.json", "Doppler.CDHelper v1"));


### PR DESCRIPTION
HI team!

In our APIs, in general, we are using [Problem Details](https://datatracker.ietf.org/doc/html/rfc7807) for error responses, but it is not working in unexpected errors.

So, following the instructions in the [official documentation](https://docs.microsoft.com/en-us/aspnet/core/web-api/handle-errors?view=aspnetcore-6.0#producing-a-problemdetails-payload-for-exceptions), I have configured a middleware for this purpose.

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/1157864/125818685-c1451163-802b-4b0a-9113-6d6bdf11b6c5.png">

<img width="893" alt="image" src="https://user-images.githubusercontent.com/1157864/125818692-abcdb698-f8d4-426d-9001-ae4db4db1200.png">

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/1157864/125818705-26eb6feb-c70e-41e3-ab11-05c59c35a52f.png">

What do you think?