### PR TITLE
Force .NET 6 preview 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /src
 COPY ./*.sh ./
 RUN shellcheck -e SC1091,SC1090 ./*.sh
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS restore
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100-preview.6-bullseye-slim AS restore
 WORKDIR /src
 COPY ./*.sln ./
 COPY */*.csproj ./
@@ -31,7 +31,7 @@ RUN dotnet test
 FROM build AS publish
 RUN dotnet publish "./Doppler.CDHelper/Doppler.CDHelper.csproj" -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS final
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-preview.6-bullseye-slim AS final
 # We need these changes in openssl.cnf to access to our SQL Server instances in QA and INT environments
 # See more information in https://stackoverflow.com/questions/56473656/cant-connect-to-sql-server-named-instance-from-asp-net-core-running-in-docker/59391426#59391426
 RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf


### PR DESCRIPTION
There is a timeout in the tests when using preview 7, for that reason are forcing preview 6.

```
#16 111.9 [xUnit.net 00:01:42.24]     Doppler.CDHelper.IntegrationTest1.PUT_hooks_should_return_problem_details_when_there_is_an_unexpected_exception [FAIL]
#16 112.0   Failed Doppler.CDHelper.IntegrationTest1.PUT_hooks_should_return_problem_details_when_there_is_an_unexpected_exception [1 m 40 s]
#16 112.0   Error Message:
#16 112.0    System.OperationCanceledException : The operation was canceled.
#16 112.0   Stack Trace:
#16 112.0      at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts) in System.Net.Http.dll:token 0x6000226+0xd9
#16 112.0    at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken) in System.Net.Http.dll:token 0x6000235+0x18f
#16 112.0    at Doppler.CDHelper.IntegrationTest1.PUT_hooks_should_return_problem_details_when_there_is_an_unexpected_exception() in /src/Doppler.CDHelper.Test/IntegrationTest1.cs:line 70
#16 112.0 --- End of stack trace from previous location ---
#16 112.0 
#16 112.0 Failed!  - Failed:     1, Passed:    12, Skipped:     0, Total:    13, Duration: 1 m 40 s - /src/Doppler.CDHelper.Test/bin/Debug/net6.0/Doppler.CDHelper.Test.dll (net6.0)
------
executor failed running [/bin/sh -c dotnet test]: exit code: 1
```

<img width="878" alt="image" src="https://user-images.githubusercontent.com/1157864/131732360-afe6e6de-a467-4085-98b6-f966b39a3b93.png">
