### PR TITLE
test: fix code to generate an empty JSON body

### DIFF
--- a/Doppler.CDHelper.Test/IntegrationTest1.cs
+++ b/Doppler.CDHelper.Test/IntegrationTest1.cs
@@ -67,7 +67,7 @@ namespace Doppler.CDHelper
                 });
 
             // Act
-            var response = await client.PostAsync("/hooks/my-secret", JsonContent.Create(new object()));
+            var response = await client.PostAsync("/hooks/my-secret", JsonContent.Create(new { }));
             var responseContent = await response.Content.ReadAsStringAsync();
 
             // Assert


### PR DESCRIPTION
Replacing `JsonContent.Create(new object())` by `JsonContent.Create(new {})` to represent an empty JSON body because it generates issues with _.NET Core v6 preview 6_, see #38