### PR TITLE
Force .NET 6 preview 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /src
 COPY ./*.sh ./
 RUN shellcheck -e SC1091,SC1090 ./*.sh
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS restore
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100-preview.7-bullseye-slim AS restore
 WORKDIR /src
 COPY ./*.sln ./
 COPY */*.csproj ./
@@ -31,7 +31,7 @@ RUN dotnet test
 FROM build AS publish
 RUN dotnet publish "./Doppler.CDHelper/Doppler.CDHelper.csproj" -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS final
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-preview.7-bullseye-slim AS final
 # We need these changes in openssl.cnf to access to our SQL Server instances in QA and INT environments
 # See more information in https://stackoverflow.com/questions/56473656/cant-connect-to-sql-server-named-instance-from-asp-net-core-running-in-docker/59391426#59391426
 RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf


### PR DESCRIPTION
Hi team!

@hrocca convinced me to use this approach to avoid unexpected breaking changes between changes in the preview versions.

His suggestion is very reasonable in many scenarios, but in my opinion, in this case, it is not so important. If something does not work, we will be noticed and it will be fixed without generated too many problems. 

But, it is interesting to experiment, in case we decided to use another beta version in another project. So, here we go...