### PR TITLE
Drop Serilog.Exceptions dependency

### DIFF
--- a/Doppler.CDHelper/Doppler.CDHelper.csproj
+++ b/Doppler.CDHelper/Doppler.CDHelper.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Flurl.Http" Version="3.2.2" />
     <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="6.1.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />


### PR DESCRIPTION
We are not using this dependency 