### PR TITLE
Fix test name

### DIFF
--- a/Doppler.CDHelper.Test/IntegrationTest1.cs
+++ b/Doppler.CDHelper.Test/IntegrationTest1.cs
@@ -45,7 +45,7 @@ namespace Doppler.CDHelper
         }
 
         [Fact]
-        public async Task PUT_hooks_should_return_problem_details_when_there_is_an_unexpected_exception()
+        public async Task POST_hooks_should_return_problem_details_when_there_is_an_unexpected_exception()
         {
             // Arrange
             var exceptionMessage = "Test unexpected exception";


### PR DESCRIPTION
Just set the correct HTTP verb that we are testing in the test name.